### PR TITLE
Set y axis text to Outflow in outflow-over-time graph

### DIFF
--- a/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowGraph.tsx
+++ b/src/extension/features/toolkit-reports/pages/outflow-over-time/OutflowGraph.tsx
@@ -20,7 +20,7 @@ export const OutflowGraph = ({ series }: { series: Highcharts.SeriesLineOptions[
       series: series,
       yAxis: {
         title: {
-          text: 'Balance',
+          text: 'Outflow',
           style: { color: textColor },
         },
         labels: {


### PR DESCRIPTION
**Explanation of Bugfix/Feature/Modification:**
I set the y axis text from "Balance" to "Outflow" in the graph of the outflow over time graph.
